### PR TITLE
Enhance script clarity, README, and add tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,37 @@ spec:
   namespace: <string> # Default: tkg-system
 ```
 
+### How it Works
+
+This plugin interacts with your Kubernetes cluster to provide information about Custom Resource Definitions (CRDs). It works by:
+1. Querying the Kubernetes API server for the OpenAPI v3 schema of the specified CRD. This schema defines the structure, data types, and validation rules for the custom resource.
+2. Traversing this retrieved schema. The script navigates through the different fields and their definitions.
+3. Generating a sample YAML output based on the schema structure. This output provides a template that you can adapt for creating actual resource instances.
+
+Default values specified in the CRD schema are indicated in the output YAML with a comment, for example: `# Default: <value>`.
+
 ### Limitations - 
 
-WIP - Since the Kubernetes core APIs generally follow a different specification, this plugin currently does not work with the core APIs and will not generate outputs for resources like Pods and Deployments. This plugin will not work for any APIs ending with `.k8s.io`. The specifications of these resources are well documented online.
+- **Core Kubernetes APIs**: This plugin is designed for third-party APIs (Custom Resources) and currently does not work with core Kubernetes APIs like Pods, Deployments, Services, etc. (typically those under `*.k8s.io` API groups).
+    - **Reasoning**: Core API schemas are often accessed via different API endpoints (e.g., `/openapi/v2` for some core components) or have a more complex structure than the `/openapi/v3/apis/{group}/{version}` path pattern primarily used for CRDs and aggregated APIs. Additionally, the schemas for core resources are extensive and are already well-documented in the official Kubernetes documentation, which is the recommended source for their specifications.
+- **Schema Variations**: While the plugin attempts to handle various CRD schema structures, some highly complex or non-standard schemas might not be rendered perfectly.
 
-## Installation 
+### Output Data Types
+
+The generated YAML uses placeholders to indicate the expected data type for each field. Here's how to interpret them:
+
+- `<string>`: Expects a string value.
+- `<integer>`: Expects an integer value.
+- `<boolean>`: Expects a boolean value (`true` or `false`).
+- `<number>`: Expects a numerical value (can be integer or float).
+- `key:` (followed by indented fields): Represents an `object` with nested key-value pairs.
+- `- <type>` or `- `: Represents an `array`.
+    - If the array items are simple types, it might look like `- <string>`.
+    - If the array items are objects, it will show `- ` followed by indented fields for that object.
+- `<no_type_specified>`: Indicates that the schema did not explicitly define a type for this field. You may need to consult the CRD's documentation.
+- `<unknown_type_in_schema>`: Indicates an unexpected or unrecognized type definition within the schema for this field.
+
+## Installation
 
 This plugin has been tested on Linux and MacOS-based systems and may need additional validation on the Windows environment. 
 

--- a/test_kubectl_genresourceyaml.py
+++ b/test_kubectl_genresourceyaml.py
@@ -1,0 +1,99 @@
+import unittest
+import io
+import sys
+from unittest.mock import patch
+
+# Assuming kubectl-genresourceyaml.py is in the same directory or accessible in PYTHONPATH
+from kubectl_genresourceyaml import traverse_spec_objects
+
+class TestTraverseSpecObjects(unittest.TestCase):
+
+    def run_test_with_schema(self, schema, expected_output):
+        """Helper function to run traverse_spec_objects and compare output."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        traverse_spec_objects(schema, 1)  # Initial indentation level of 1
+        sys.stdout = sys.__stdout__  # Reset stdout
+        self.assertEqual(captured_output.getvalue().strip(), expected_output.strip())
+
+    def test_various_data_types_and_structures(self):
+        sample_schema = {
+            "stringField": {"type": "string"},
+            "stringFieldWithDefault": {"type": "string", "default": "hello"},
+            "integerField": {"type": "integer"},
+            "integerFieldWithDefault": {"type": "integer", "default": 123},
+            "booleanField": {"type": "boolean"},
+            "booleanFieldWithDefault": {"type": "boolean", "default": True},
+            "numberField": {"type": "number"},
+            "numberFieldWithDefault": {"type": "number", "default": 3.14},
+            "noTypeField": {},
+            "arrayOfString": {
+                "type": "array",
+                "items": {"type": "string"}
+            },
+            "arrayOfStringWithDefault": {
+                "type": "array",
+                "items": {"type": "string"},
+                "default": ["a", "b"]
+            },
+            "arrayOfObjects": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "nestedString": {"type": "string"},
+                        "nestedIntWithDefault": {"type": "integer", "default": 42}
+                    }
+                }
+            },
+            "nestedObject": {
+                "type": "object",
+                "properties": {
+                    "childString": {"type": "string"},
+                    "childObject": {
+                        "type": "object",
+                        "properties": {
+                            "grandchildBoolean": {"type": "boolean", "default": False}
+                        }
+                    }
+                }
+            },
+            "arrayWithNoItemType": { # Test case for array with no item type
+                "type": "array",
+                "items": {}
+            },
+            "objectWithNoProperties":{ # Test case for object with no properties
+                "type": "object"
+            }
+        }
+
+        expected_output = """
+ stringField: <string>
+ stringFieldWithDefault: <string> # Default: hello
+ integerField: <integer>
+ integerFieldWithDefault: <integer> # Default: 123
+ booleanField: <boolean>
+ booleanFieldWithDefault: <boolean> # Default: True
+ numberField: <number>
+ numberFieldWithDefault: <number> # Default: 3.14
+ noTypeField: <no_type_specified>
+ arrayOfString: 
+  - <string>
+ arrayOfStringWithDefault: 
+  - <string> # Default: ['a', 'b']
+ arrayOfObjects:
+  - 
+   nestedString: <string>
+   nestedIntWithDefault: <integer> # Default: 42
+ nestedObject:
+  childString: <string>
+  childObject:
+   grandchildBoolean: <boolean> # Default: False
+ arrayWithNoItemType: 
+  - <no_type_specified>
+ objectWithNoProperties:
+"""
+        self.run_test_with_schema(sample_schema, expected_output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces several improvements:

kubectl-genresourceyaml.py:
- Added detailed comments to `traverse_spec_objects` for better understanding of type handling.
- Improved output for undefined types from "<>" to "<no_type_specified>".
- Made `object` type handling explicit in `traverse_spec_objects`.
- Confirmed consistent display of default values.

README.md:
- Added a "How it Works" section.
- Expanded the "Limitations" section with more context on core API incompatibility.
- Added an "Output Data Types" section to explain YAML placeholders.
- Clarified how default values are shown in the output.

Tests:
- Introduced `test_kubectl_genresourceyaml.py` with unit tests for `traverse_spec_objects`.
- Tests cover various data types, nested structures, arrays, default values, and undefined types to ensure robust output generation.